### PR TITLE
Fix skill list loading and optimize admin flow

### DIFF
--- a/app/api/admin/sign/stream/route.js
+++ b/app/api/admin/sign/stream/route.js
@@ -1,0 +1,91 @@
+export const runtime = "edge";
+
+import { signReviewToken } from "@/lib/token";
+import { findEmployeesByTeam, listReviewersForEmployees } from "@/lib/notion";
+
+function t(s) {
+  return (s || "").trim();
+}
+
+export async function POST(req) {
+  const { readable, writable } = new TransformStream();
+  const writer = writable.getWriter();
+  const encoder = new TextEncoder();
+  const send = (data) => writer.write(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+  (async () => {
+    try {
+      let body = {};
+      try {
+        body = await req.json();
+      } catch {
+        send({ error: "Некорректный JSON" });
+        return;
+      }
+
+      const teamName = t(body.teamName);
+      const expDays = Number(body.expDays || 14);
+      const adminKey = t(body.adminKey);
+
+      if (!teamName) {
+        send({ error: "Название команды обязательно" });
+        return;
+      }
+      if (t(process.env.ADMIN_KEY) !== adminKey) {
+        send({ error: "Неверный ключ администратора" });
+        return;
+      }
+
+      const employees = await findEmployeesByTeam(teamName);
+      if (!employees?.length) {
+        send({ error: `Команда \"${teamName}\" не найдена` });
+        return;
+      }
+
+      const reviewers = await listReviewersForEmployees(employees);
+      if (!reviewers?.length) {
+        send({ error: `Не найдено ревьюеров для команды \"${teamName}\"` });
+        return;
+      }
+
+      send({ progress: 0, total: reviewers.length });
+
+      const exp = Math.floor(Date.now() / 1000) + expDays * 24 * 3600;
+      const links = [];
+
+      for (const reviewer of reviewers) {
+        try {
+          const token = await signReviewToken({
+            reviewerUserId: reviewer.reviewerUserId,
+            role: reviewer.role || "peer",
+            teamName,
+            exp
+          });
+          links.push({
+            name: reviewer.name,
+            url: `${process.env.NEXT_PUBLIC_BASE_URL}/form/${token}`,
+            userId: reviewer.reviewerUserId,
+            role: reviewer.role || "peer"
+          });
+        } catch (error) {
+          send({ error: `Ошибка генерации для ${reviewer.name}: ${error.message}` });
+        }
+        send({ progress: Math.round((links.length / reviewers.length) * 100) });
+      }
+
+      send({ done: true, teamName, count: links.length, links, progress: 100 });
+    } catch (error) {
+      send({ error: error.message || "Неизвестная ошибка" });
+    } finally {
+      writer.close();
+    }
+  })();
+
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive"
+    }
+  });
+}

--- a/app/form/[token]/page.jsx
+++ b/app/form/[token]/page.jsx
@@ -141,31 +141,31 @@ export default function FormPage({ params }) {
   // Загрузка данных с retry логикой
   useEffect(() => {
     if (!mounted) return;
-    
+
     const maxRetries = 2;
     let timeoutId;
-    
+
     const attemptLoad = async () => {
       await loadData();
-      
+
       // Если загрузка не удалась и есть попытки - повторяем
       if (loadError && retryCount < maxRetries) {
         const delay = Math.min(1000 * (retryCount + 1), 3000);
         console.log(`[LOAD] Retrying in ${delay}ms...`);
         setMsg(`Попытка ${retryCount + 1} не удалась, повтор через ${delay/1000}с...`);
-        
+
         timeoutId = setTimeout(() => {
           setRetryCount(prev => prev + 1);
         }, delay);
       }
     };
-    
+
     attemptLoad();
-    
+
     return () => {
       if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [loadData, retryCount]);
+  }, [mounted, loadData, retryCount, loadError]);
 
   // Оптимизированный обработчик изменений
   const onRowChange = useCallback((pageId) => (newData) => {

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -120,8 +120,9 @@ let lastRequest = 0;
 async function simpleRateLimit() {
   const now = Date.now();
   const timeSinceLastRequest = now - lastRequest;
-  if (timeSinceLastRequest < 300) {
-    await new Promise(resolve => setTimeout(resolve, 300 - timeSinceLastRequest));
+  // Уменьшаем задержку между запросами для ускорения генерации
+  if (timeSinceLastRequest < 100) {
+    await new Promise(resolve => setTimeout(resolve, 100 - timeSinceLastRequest));
   }
   lastRequest = Date.now();
 }
@@ -1014,45 +1015,51 @@ export async function fetchEmployeeSkillRowsForReviewerUser(employees, reviewerU
         // Загружаем информацию о навыках с контролем скорости
         const items = [];
         const skillEntries = Array.from(uniqueSkills.values());
-        
-        // Батчевая обработка для оптимизации
-        const BATCH_SIZE = 3; // Уменьшено для снижения нагрузки
+
+        // Обрабатываем навыки параллельно небольшими батчами
+        const BATCH_SIZE = 3;
         for (let i = 0; i < skillEntries.length; i += BATCH_SIZE) {
           const batch = skillEntries.slice(i, i + BATCH_SIZE);
-          
-          console.log(`[SKILLS] Processing batch ${Math.floor(i/BATCH_SIZE) + 1}/${Math.ceil(skillEntries.length/BATCH_SIZE)} for ${employee.employeeName}`);
-          
-          for (const skillEntry of batch) {
-            try {
-              const skillInfo = await loadSkillInformation(skillEntry.skillId, skillEntry.matrixRowProps);
-              
-              items.push({
-                pageId: skillEntry.pageId,
-                name: skillInfo.name,
-                description: skillInfo.description,
-                current: skillEntry.current,
-                comment: ""
-              });
-              
-              console.log(`[SKILLS] ✅ Loaded skill: ${skillInfo.name}`);
-              
-            } catch (skillError) {
-              console.error(`[SKILLS] Error loading skill ${skillEntry.skillId}:`, skillError.message);
-              
-              items.push({
-                pageId: skillEntry.pageId,
-                name: `Навык ${skillEntry.skillId.substring(-8)}`,
-                description: `Ошибка загрузки: ${skillError.message}`,
-                current: skillEntry.current,
-                comment: ""
-              });
-            }
-          }
-          
-          // Пауза между батчами для снижения нагрузки на Notion API
-          if (i + BATCH_SIZE < skillEntries.length) {
-            await new Promise(r => setTimeout(r, 500));
-          }
+
+          console.log(
+            `[SKILLS] Processing batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(skillEntries.length / BATCH_SIZE)} for ${employee.employeeName}`
+          );
+
+          const batchResults = await Promise.all(
+            batch.map(async (skillEntry) => {
+              try {
+                const skillInfo = await loadSkillInformation(
+                  skillEntry.skillId,
+                  skillEntry.matrixRowProps
+                );
+
+                console.log(`[SKILLS] ✅ Loaded skill: ${skillInfo.name}`);
+
+                return {
+                  pageId: skillEntry.pageId,
+                  name: skillInfo.name,
+                  description: skillInfo.description,
+                  current: skillEntry.current,
+                  comment: ""
+                };
+              } catch (skillError) {
+                console.error(
+                  `[SKILLS] Error loading skill ${skillEntry.skillId}:`,
+                  skillError.message
+                );
+
+                return {
+                  pageId: skillEntry.pageId,
+                  name: `Навык ${skillEntry.skillId.slice(-8)}`,
+                  description: `Ошибка загрузки: ${skillError.message}`,
+                  current: skillEntry.current,
+                  comment: ""
+                };
+              }
+            })
+          );
+
+          items.push(...batchResults);
         }
 
         if (items.length > 0) {


### PR DESCRIPTION
## Summary
- ensure form page loads skill data after mount
- parallelize Notion skill fetches and lighten rate limiting
- smooth admin progress bar animation
- stream real-time link generation progress to admin page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a337b6687c8320808902f0ea0e9656