### PR TITLE
fix: handle module import for edge runtime

### DIFF
--- a/app/api/form/[token]/route.js
+++ b/app/api/form/[token]/route.js
@@ -2,11 +2,21 @@ export const runtime = "edge";
 
 import { NextResponse } from "next/server";
 
+// Карта модулей для явного импорта (решает проблемы сборки на Edge)
+const moduleMap = {
+  "@/lib/token": () => import("@/lib/token"),
+  "@/lib/notion": () => import("@/lib/notion")
+};
+
 // Безопасный импорт с обработкой ошибок
 async function safeImport(moduleName) {
+  const importer = moduleMap[moduleName];
+  if (!importer) {
+    throw new Error(`Неизвестный модуль: ${moduleName}`);
+  }
   try {
     console.log(`[SAFE IMPORT] Попытка импорта ${moduleName}`);
-    const module = await import(moduleName);
+    const module = await importer();
     console.log(`[SAFE IMPORT] Успешно импортирован ${moduleName}`);
     return module;
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure server modules are explicitly mapped for safe import on Edge runtime

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3949c9a7c832096662aca47fe8414