### PR TITLE
Improve competency form UI and skill loading

### DIFF
--- a/app/form/[token]/page.jsx
+++ b/app/form/[token]/page.jsx
@@ -378,47 +378,6 @@ export default function SkillsAssessmentForm({ params }) {
               Оцените уровень владения навыками по шкале от 0 до 5
             </p>
             
-            {stats && (
-              <div style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
-                gap: 16,
-                marginTop: 24
-              }}>
-                <div style={{ textAlign: 'center' }}>
-                  <div style={{ fontSize: 24, fontWeight: 600, color: '#007bff' }}>
-                    {skillGroups.length}
-                  </div>
-                  <div style={{ fontSize: 14, color: '#6c757d' }}>
-                    Сотрудников
-                  </div>
-                </div>
-                <div style={{ textAlign: 'center' }}>
-                  <div style={{ fontSize: 24, fontWeight: 600, color: '#28a745' }}>
-                    {totalSkills}
-                  </div>
-                  <div style={{ fontSize: 14, color: '#6c757d' }}>
-                    Навыков
-                  </div>
-                </div>
-                <div style={{ textAlign: 'center' }}>
-                  <div style={{ fontSize: 24, fontWeight: 600, color: '#ffc107' }}>
-                    {ratedSkills}
-                  </div>
-                  <div style={{ fontSize: 14, color: '#6c757d' }}>
-                    Оценено
-                  </div>
-                </div>
-                <div style={{ textAlign: 'center' }}>
-                  <div style={{ fontSize: 24, fontWeight: 600, color: '#17a2b8' }}>
-                    {stats.reviewerRole || 'peer'}
-                  </div>
-                  <div style={{ fontSize: 14, color: '#6c757d' }}>
-                    Роль
-                  </div>
-                </div>
-              </div>
-            )}
           </div>
 
           {/* Прогресс-бар */}

--- a/components/ScoreRow.jsx
+++ b/components/ScoreRow.jsx
@@ -98,7 +98,6 @@ ScoreButton.displayName = 'ScoreButton';
 const ScoreRow = memo(({ item, onChange, hideComment = false }) => {
   const [val, setVal] = useState(() => clamp(item.current ?? 0));
   const [isDirty, setIsDirty] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
   
   const debouncedChange = useDebounce(
     useCallback((newValue) => {
@@ -120,8 +119,6 @@ const ScoreRow = memo(({ item, onChange, hideComment = false }) => {
     debouncedChange(val);
   }, []);
   
-  // Проверяем, нужна ли кнопка "показать больше"
-  const needsExpansion = item.description && item.description.length > 200;
   
   const scoreLabels = {
     0: "Нет опыта",
@@ -160,44 +157,17 @@ const ScoreRow = memo(({ item, onChange, hideComment = false }) => {
           
           {item.description && (
             <div style={{ marginBottom: 12 }}>
-              <div 
+              <div
                 style={{
-                  color: '#495057', 
-                  fontSize: 14, 
+                  color: '#495057',
+                  fontSize: 14,
                   lineHeight: 1.5,
                   whiteSpace: 'pre-wrap',
-                  wordWrap: 'break-word',
-                  overflow: 'hidden',
-                  ...(needsExpansion && !isExpanded && {
-                    display: "-webkit-box",
-                    WebkitLineClamp: 3,
-                    WebkitBoxOrient: "vertical",
-                  })
+                  wordWrap: 'break-word'
                 }}
               >
                 {item.description}
               </div>
-              {needsExpansion && (
-                <button
-                  style={{
-                    background: "none",
-                    border: "none",
-                    color: "#007bff",
-                    cursor: "pointer",
-                    fontSize: 13,
-                    marginTop: 6,
-                    padding: "4px 0",
-                    textDecoration: "none",
-                    fontWeight: 500
-                  }}
-                  onClick={() => setIsExpanded(!isExpanded)}
-                  type="button"
-                  onMouseEnter={(e) => e.target.style.textDecoration = "underline"}
-                  onMouseLeave={(e) => e.target.style.textDecoration = "none"}
-                >
-                  {isExpanded ? "↑ Свернуть" : "↓ Показать полностью"}
-                </button>
-              )}
             </div>
           )}
 
@@ -266,37 +236,6 @@ const ScoreRow = memo(({ item, onChange, hideComment = false }) => {
             ))}
           </div>
 
-          {/* Слайдер как дополнительный элемент управления */}
-          <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 12,
-            width: '100%',
-            maxWidth: 320
-          }}>
-            <span style={{ fontSize: 12, color: '#6c757d', minWidth: 20 }}>0</span>
-            <input
-              type="range"
-              min={0}
-              max={5}
-              step={1}
-              value={val}
-              style={{
-                flex: 1,
-                height: 6,
-                background: `linear-gradient(to right, #007bff 0%, #007bff ${(val/5)*100}%, #e9ecef ${(val/5)*100}%, #e9ecef 100%)`,
-                borderRadius: 3,
-                outline: 'none',
-                cursor: 'pointer',
-                appearance: 'none',
-                WebkitAppearance: 'none',
-                MozAppearance: 'none'
-              }}
-              onChange={(e) => handleValueChange(Number(e.target.value))}
-              aria-label={`Оценка для ${item.name}`}
-            />
-            <span style={{ fontSize: 12, color: '#6c757d', minWidth: 20 }}>5</span>
-          </div>
         </div>
       </div>
 

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -819,24 +819,24 @@ async function loadSkillInformation(skillId, matrixRowProps) {
     if (matrixRowProps && matrixRowProps[PROP.skillDescription]) {
       const rollupField = matrixRowProps[PROP.skillDescription];
       console.log(`[SKILL LOAD] Found rollup field, type: ${rollupField?.type}`);
-      
+
       // Rollup поле может содержать массив значений
       if (rollupField?.type === "rollup" && rollupField.rollup?.array) {
         const rollupValues = rollupField.rollup.array;
         console.log(`[SKILL LOAD] Rollup array has ${rollupValues.length} values`);
-        
+
         if (rollupValues.length > 0) {
           // Берем первое непустое значение из rollup
           for (const value of rollupValues) {
             if (value?.rich_text?.length > 0) {
               skillDescription = value.rich_text.map(t => t.plain_text).join("");
               console.log(`[SKILL LOAD] Found description in rollup rich_text`);
-              break;
-            } else if (value?.title?.length > 0) {
+            }
+            if (value?.title?.length > 0) {
               skillName = value.title.map(t => t.plain_text).join("");
               console.log(`[SKILL LOAD] Found name in rollup title`);
-              break;
             }
+            if (skillDescription && skillName !== "Неизвестный навык") break;
           }
         }
       } else if (rollupField?.rollup?.rich_text?.length > 0) {
@@ -847,69 +847,68 @@ async function loadSkillInformation(skillId, matrixRowProps) {
         skillName = rollupField.rollup.title.map(t => t.plain_text).join("");
         console.log(`[SKILL LOAD] Found name in simple rollup title`);
       }
-      
-      if (skillDescription) {
+
+      if (skillDescription && skillName === "Неизвестный навык") {
         // Пытаемся извлечь название из начала описания
         const lines = skillDescription.split('\n');
         if (lines.length > 0 && lines[0].trim().length > 0 && lines[0].length < 100) {
           skillName = lines[0].trim();
         }
-        
-        const result = { name: skillName, description: skillDescription };
-        setCached(cacheKey, result);
-        console.log(`[SKILL LOAD] ✅ Used rollup data for skill: ${skillName}`);
-        return result;
       }
     }
-    
-    // Если rollup пустой, пытаемся загрузить страницу навыка напрямую
+
+    // Загружаем страницу навыка напрямую, если имя все еще неизвестно или нет описания
     try {
-      console.log(`[SKILL LOAD] Rollup empty, trying direct page load for: ${skillId}`);
-      
-      const skillPage = await notionApiCall(() => 
-        notion.pages.retrieve({ page_id: skillId })
-      );
-      
-      const props = skillPage.properties || {};
-      
-      // Ищем title поле
-      const pageTitle = getTitleFromProps(props);
-      if (pageTitle && pageTitle.trim() && pageTitle !== "Untitled") {
-        skillName = pageTitle.trim();
-        console.log(`[SKILL LOAD] Found skill name: ${skillName}`);
-      }
-      
-      // Ищем описание в свойствах страницы навыка
-      for (const [key, value] of Object.entries(props)) {
-        if (value?.type === "rich_text" && value.rich_text?.length > 0) {
-          const keyLower = key.toLowerCase();
-          if (keyLower.includes("описан") || 
-              keyLower.includes("description") ||
-              keyLower.includes("дескрипш") ||
-              keyLower.includes("content") ||
-              keyLower.includes("детал") ||
-              keyLower.includes("text")) {
-            skillDescription = value.rich_text.map(t => t.plain_text).join("");
-            console.log(`[SKILL LOAD] Found description in field: ${key}`);
-            break;
+      if (skillName === "Неизвестный навык" || !skillDescription) {
+        console.log(`[SKILL LOAD] Fetching skill page for: ${skillId}`);
+
+        const skillPage = await notionApiCall(() =>
+          notion.pages.retrieve({ page_id: skillId })
+        );
+
+        const props = skillPage.properties || {};
+
+        // Ищем title поле
+        const pageTitle = getTitleFromProps(props);
+        if (pageTitle && pageTitle.trim() && pageTitle !== "Untitled") {
+          skillName = pageTitle.trim();
+          console.log(`[SKILL LOAD] Found skill name: ${skillName}`);
+        }
+
+        // Ищем описание в свойствах страницы навыка, только если еще нет описания
+        if (!skillDescription) {
+          for (const [key, value] of Object.entries(props)) {
+            if (value?.type === "rich_text" && value.rich_text?.length > 0) {
+              const keyLower = key.toLowerCase();
+              if (keyLower.includes("описан") ||
+                  keyLower.includes("description") ||
+                  keyLower.includes("дескрипш") ||
+                  keyLower.includes("content") ||
+                  keyLower.includes("детал") ||
+                  keyLower.includes("text")) {
+                skillDescription = value.rich_text.map(t => t.plain_text).join("");
+                console.log(`[SKILL LOAD] Found description in field: ${key}`);
+                break;
+              }
+            }
           }
         }
       }
-      
+
       const result = { name: skillName, description: skillDescription };
       setCached(cacheKey, result);
-      console.log(`[SKILL LOAD] ✅ Loaded skill from page: ${skillName}`);
+      console.log(`[SKILL LOAD] ✅ Loaded skill: ${skillName}`);
       return result;
-      
+
     } catch (pageError) {
       console.warn(`[SKILL LOAD] Failed to load skill page ${skillId}:`, pageError.message);
-      
+
       // Используем ID как fallback название
       if (skillName === "Неизвестный навык") {
         skillName = `Навык ${skillId.substring(-8)}`;
       }
     }
-    
+
     const result = { name: skillName, description: skillDescription };
     setCached(cacheKey, result);
     return result;


### PR DESCRIPTION
## Summary
- fetch skill names even when description comes from rollup
- simplify assessment form header and controls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a44089a67c8320863ef35976f33911