### PR TITLE
Fix competency form alignment and add load time counter

### DIFF
--- a/app/form/[token]/page.jsx
+++ b/app/form/[token]/page.jsx
@@ -119,10 +119,12 @@ function useSkillsData(token) {
     loading: true,
     error: null,
     scoreData: new Map(),
-    stats: null
+    stats: null,
+    loadTime: 0
   });
 
   const fetchSkills = useCallback(async () => {
+    const start = performance.now();
     setState(prev => ({ ...prev, loading: true, error: null }));
     
     try {
@@ -174,12 +176,13 @@ function useSkillsData(token) {
       const skillGroups = Object.values(grouped);
       console.log(`Загружено ${skillGroups.length} групп навыков`);
       
-      setState(prev => ({ 
-        ...prev, 
-        skillGroups, 
+      setState(prev => ({
+        ...prev,
+        skillGroups,
         loading: false,
         error: null,
-        stats: result.stats
+        stats: result.stats,
+        loadTime: (performance.now() - start) / 1000
       }));
       
     } catch (error) {
@@ -228,6 +231,7 @@ export default function SkillsAssessmentForm({ params }) {
     error,
     scoreData,
     stats,
+    loadTime,
     updateSkillScore,
     refetch
   } = useSkillsData(token);
@@ -618,6 +622,16 @@ export default function SkillsAssessmentForm({ params }) {
           </form>
         </div>
       </StateHandler>
+      {!loading && (
+        <div style={{
+          textAlign: 'center',
+          color: '#6c757d',
+          fontSize: 12,
+          paddingBottom: 24
+        }}>
+          Страница загрузилась за {loadTime.toFixed(2)} сек.
+        </div>
+      )}
     </div>
   );
 }

--- a/components/ScoreRow.jsx
+++ b/components/ScoreRow.jsx
@@ -191,14 +191,15 @@ const ScoreRow = memo(({ item, onChange, hideComment = false }) => {
           flexDirection: 'column',
           alignItems: 'flex-end',
           gap: 12,
-          minWidth: 360
+          width: 360
         }}>
           {/* Кнопки оценки */}
           <div style={{
-            display: 'flex',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(6, 1fr)',
             gap: 12,
-            flexWrap: 'wrap',
-            justifyContent: 'flex-end'
+            justifyItems: 'center',
+            width: '100%'
           }}>
             {[0, 1, 2, 3, 4, 5].map((score) => (
               <ScoreButton
@@ -219,7 +220,7 @@ const ScoreRow = memo(({ item, onChange, hideComment = false }) => {
             fontSize: 11,
             color: '#6c757d',
             textAlign: 'center',
-            maxWidth: 360
+            width: '100%'
           }}>
             {Object.values(scoreLabels).map((label, index) => (
               <div key={index} style={{


### PR DESCRIPTION
## Summary
- align rating scale descriptions with their numeric buttons
- display page load time at the bottom of the competency form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing environment variables NOTION_TOKEN, MATRIX_DB_ID, EMPLOYEES_DB_ID, JWT_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a451e63458832094a0dffa991ec81e