### PR TITLE
Add Notion export for review links

### DIFF
--- a/app/api/admin/export-links/route.js
+++ b/app/api/admin/export-links/route.js
@@ -1,0 +1,40 @@
+export const runtime = "edge";
+
+import { NextResponse } from "next/server";
+import { getEmployeePagesByUserId, setEmployeeUrl } from "@/lib/notion";
+
+export async function POST(req) {
+  try {
+    const adminKey = (req.headers.get("x-admin-key") || "").trim();
+    if (!adminKey || adminKey !== (process.env.ADMIN_KEY || "").trim()) {
+      return NextResponse.json({ error: "Неверный ключ администратора" }, { status: 403 });
+    }
+
+    let body = {};
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json({ error: "Некорректный JSON" }, { status: 400 });
+    }
+
+    const items = Array.isArray(body.links) ? body.links : [];
+    let updated = 0;
+
+    for (const { userId, url } of items) {
+      if (!userId || !url) continue;
+      const pages = await getEmployeePagesByUserId(userId);
+      if (!pages.length) continue;
+      try {
+        await setEmployeeUrl(pages[0].pageId, url);
+        updated++;
+      } catch (error) {
+        console.error('[EXPORT LINKS] Failed to update', userId, error);
+      }
+    }
+
+    return NextResponse.json({ ok: true, updated });
+  } catch (error) {
+    console.error('[EXPORT LINKS] Critical error:', error);
+    return NextResponse.json({ error: "Ошибка сервера" }, { status: 500 });
+  }
+}

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -1106,7 +1106,21 @@ export async function updateScore(pageId, field, value) {
   const properties = {
     [field]: { number: value }
   };
-  
+
+  return await notionApiCall(() =>
+    notion.pages.update({
+      page_id: pageId,
+      properties
+    })
+  );
+}
+
+// Установка URL страницы сотрудника
+export async function setEmployeeUrl(pageId, url) {
+  const properties = {
+    URL: { url }
+  };
+
   return await notionApiCall(() =>
     notion.pages.update({
       page_id: pageId,


### PR DESCRIPTION
## Summary
- remove CSV export and link copy actions from admin page
- add button to export review links to Notion employees database
- implement API route and utility to update Notion URL fields

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a45df87bdc83208b9fd1e1308f33a8