### PR TITLE
feat: add async notion write queue

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -1115,6 +1115,32 @@ export async function updateScore(pageId, field, value) {
   );
 }
 
+// Очередь для асинхронных обновлений оценок
+const scoreUpdateQueue = [];
+let isScoreQueueProcessing = false;
+
+export function queueScoreUpdate(pageId, field, value) {
+  scoreUpdateQueue.push({ pageId, field, value });
+  processScoreQueue();
+}
+
+async function processScoreQueue() {
+  if (isScoreQueueProcessing) return;
+  isScoreQueueProcessing = true;
+
+  while (scoreUpdateQueue.length > 0) {
+    const { pageId, field, value } = scoreUpdateQueue.shift();
+    try {
+      await updateScore(pageId, field, value);
+      console.log(`[QUEUE] Updated ${pageId}: ${field} = ${value}`);
+    } catch (error) {
+      console.error(`[QUEUE] Error updating ${pageId}:`, error.message);
+    }
+  }
+
+  isScoreQueueProcessing = false;
+}
+
 // Установка URL страницы сотрудника
 export async function setEmployeeUrl(pageId, url) {
   const properties = {


### PR DESCRIPTION
## Summary
- introduce in-memory queue for asynchronous Notion score updates
- enqueue score updates in form submission endpoint and respond immediately

## Testing
- ⚠️ `npm test` (missing script: test)
- ⚠️ `npm run build` (missing Notion env vars)


------
https://chatgpt.com/codex/tasks/task_e_68a4646e16f48320ba3b7ceaebae1fb8