### PR TITLE
Fix competency score submissions to Notion

### DIFF
--- a/app/api/form/[token]/route.js
+++ b/app/api/form/[token]/route.js
@@ -505,8 +505,8 @@ export async function POST(req, { params }) {
       const itemRole = item.role && ROLE_TO_FIELD[item.role] ? item.role : role;
       const field = ROLE_TO_FIELD[itemRole] || ROLE_TO_FIELD.peer;
 
-      console.log(`[FORM POST] Добавление в очередь ${index + 1}/${items.length}: ${item.pageId} = ${item.value} -> ${field}`);
-      queueScoreUpdate(item.pageId, field, item.value);
+      console.log(`[FORM POST] Добавление ${index + 1}/${items.length}: ${item.pageId} = ${item.value} -> ${field}`);
+      await queueScoreUpdate(item.pageId, field, item.value);
 
       results.push({
         pageId: item.pageId,
@@ -517,7 +517,7 @@ export async function POST(req, { params }) {
 
     const duration = PerformanceTracker?.end('batch-update') || 0;
 
-    console.log(`[FORM POST] В очередь добавлено ${results.length} элементов за ${duration}ms`);
+    console.log(`[FORM POST] Обновлено ${results.length} элементов за ${duration}ms`);
 
     const response = {
       ok: true,
@@ -525,7 +525,7 @@ export async function POST(req, { params }) {
       mode,
       reviewerRole: role,
       duration,
-      message: `Добавлено в очередь ${results.length} оценок`
+      message: `Обновлено ${results.length} оценок`
     };
 
     return NextResponse.json(response);

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -1120,8 +1120,10 @@ const scoreUpdateQueue = [];
 let isScoreQueueProcessing = false;
 
 export function queueScoreUpdate(pageId, field, value) {
-  scoreUpdateQueue.push({ pageId, field, value });
-  processScoreQueue();
+  return new Promise((resolve, reject) => {
+    scoreUpdateQueue.push({ pageId, field, value, resolve, reject });
+    processScoreQueue();
+  });
 }
 
 async function processScoreQueue() {
@@ -1129,12 +1131,14 @@ async function processScoreQueue() {
   isScoreQueueProcessing = true;
 
   while (scoreUpdateQueue.length > 0) {
-    const { pageId, field, value } = scoreUpdateQueue.shift();
+    const { pageId, field, value, resolve, reject } = scoreUpdateQueue.shift();
     try {
       await updateScore(pageId, field, value);
       console.log(`[QUEUE] Updated ${pageId}: ${field} = ${value}`);
+      resolve?.();
     } catch (error) {
       console.error(`[QUEUE] Error updating ${pageId}:`, error.message);
+      reject?.(error);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure score updates return a promise and are awaited
- wait for queue to flush when saving competency scores

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a47b95d8bc8320ac845cb3ed145f57