### PR TITLE
Handle non-JSON responses on competency form submission

### DIFF
--- a/app/form/[token]/page.jsx
+++ b/app/form/[token]/page.jsx
@@ -269,16 +269,23 @@ export default function SkillsAssessmentForm({ params }) {
       
       const response = await fetch(`/api/form/${token}`, {
         method: 'POST',
-        headers: { 
-          'Content-Type': 'application/json' 
+        headers: {
+          'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ 
+        body: JSON.stringify({
           items,
           mode: 'final'
         })
       });
 
-      const result = await response.json();
+      const raw = await response.text();
+      let result = {};
+
+      try {
+        result = raw ? JSON.parse(raw) : {};
+      } catch {
+        throw new Error('сервер вернул некорректный ответ');
+      }
 
       if (!response.ok) {
         throw new Error(result.error || 'Ошибка отправки данных');
@@ -319,16 +326,23 @@ export default function SkillsAssessmentForm({ params }) {
 
       const response = await fetch(`/api/form/${token}`, {
         method: 'POST',
-        headers: { 
-          'Content-Type': 'application/json' 
+        headers: {
+          'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ 
+        body: JSON.stringify({
           items,
           mode: 'draft'
         })
       });
 
-      const result = await response.json();
+      const raw = await response.text();
+      let result = {};
+
+      try {
+        result = raw ? JSON.parse(raw) : {};
+      } catch {
+        throw new Error('сервер вернул некорректный ответ');
+      }
 
       if (!response.ok) {
         throw new Error(result.error || 'Ошибка сохранения черновика');


### PR DESCRIPTION
## Summary
- Handle API responses that return HTML or other non-JSON payloads on competency assessment form submissions
- Display a user-friendly error when server returns invalid data instead of showing JSON parse error

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a480cf8cbc8320b7569dec9e00598f