### PR TITLE
Remove draft save option

### DIFF
--- a/app/api/form/[token]/route.js
+++ b/app/api/form/[token]/route.js
@@ -452,8 +452,7 @@ export async function POST(req, { params }) {
     try {
       body = await req.json();
       console.log('[FORM POST] Получены данные:', {
-        itemsCount: body.items?.length || 0,
-        mode: body.mode || 'final'
+        itemsCount: body.items?.length || 0
       });
     } catch (error) {
       console.error('[FORM POST] Ошибка парсинга JSON:', error.message);
@@ -493,7 +492,7 @@ export async function POST(req, { params }) {
       }
     }
     
-    const { items, mode } = { items: body.items, mode: body.mode || "final" };
+    const items = body.items;
 
     console.log(`[FORM POST] Роль из токена: ${role}`);
     
@@ -531,7 +530,6 @@ export async function POST(req, { params }) {
     const response = {
       ok: true,
       queued: results.length,
-      mode,
       reviewerRole: role,
       duration,
       message: `Обновлено ${results.length} оценок`

--- a/app/form/[token]/page.jsx
+++ b/app/form/[token]/page.jsx
@@ -272,10 +272,7 @@ export default function SkillsAssessmentForm({ params }) {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-          items,
-          mode: 'final'
-        })
+        body: JSON.stringify({ items })
       });
 
       const raw = await response.text();
@@ -308,60 +305,6 @@ export default function SkillsAssessmentForm({ params }) {
     }
   }, [scoreData, token]);
 
-  const handleSaveDraft = useCallback(async () => {
-    if (scoreData.size === 0) {
-      setSubmitMessage('❌ Нет данных для сохранения');
-      return;
-    }
-
-    setSubmitting(true);
-    setSubmitMessage('');
-    
-    try {
-      const items = Array.from(scoreData.entries()).map(([pageId, scoreInfo]) => ({
-        pageId,
-        value: scoreInfo.value,
-        role: scoreInfo.role
-      }));
-
-      const response = await fetch(`/api/form/${token}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          items,
-          mode: 'draft'
-        })
-      });
-
-      const raw = await response.text();
-      let result = {};
-
-      try {
-        result = raw ? JSON.parse(raw) : {};
-      } catch {
-        throw new Error('сервер вернул некорректный ответ');
-      }
-
-      if (!response.ok) {
-        throw new Error(result.error || 'Ошибка сохранения черновика');
-      }
-
-      if (result.ok) {
-        setSubmitMessage(`💾 Черновик сохранен (${result.queued} оценок)`);
-      }
-      
-    } catch (error) {
-      console.error('Ошибка сохранения черновика:', error);
-      const msg = error.message === 'Failed to fetch'
-        ? 'не удалось связаться с сервером'
-        : error.message;
-      setSubmitMessage(`❌ Ошибка сохранения: ${msg}`);
-    } finally {
-      setSubmitting(false);
-    }
-  }, [scoreData, token]);
 
   return (
     <div style={{ 
@@ -574,25 +517,6 @@ export default function SkillsAssessmentForm({ params }) {
 
                 <div style={{ display: 'flex', gap: 12 }}>
                   <button
-                    type="button"
-                    onClick={handleSaveDraft}
-                    disabled={submitting || ratedSkills === 0}
-                    style={{
-                      padding: '12px 20px',
-                      backgroundColor: submitting ? '#6c757d' : '#6f42c1',
-                      color: 'white',
-                      border: 'none',
-                      borderRadius: 8,
-                      fontSize: 14,
-                      fontWeight: 600,
-                      cursor: submitting || ratedSkills === 0 ? 'not-allowed' : 'pointer',
-                      transition: 'background-color 0.2s ease'
-                    }}
-                  >
-                    💾 Сохранить черновик
-                  </button>
-
-                  <button
                     type="submit"
                     disabled={submitting || ratedSkills === 0}
                     style={{
@@ -618,10 +542,8 @@ export default function SkillsAssessmentForm({ params }) {
                   marginTop: 16,
                   padding: 12,
                   borderRadius: 8,
-                  backgroundColor: submitMessage.includes('❌') ? '#f8d7da' : 
-                                  submitMessage.includes('💾') ? '#d1ecf1' : '#d4edda',
-                  color: submitMessage.includes('❌') ? '#721c24' : 
-                         submitMessage.includes('💾') ? '#0c5460' : '#155724',
+                  backgroundColor: submitMessage.includes('❌') ? '#f8d7da' : '#d4edda',
+                  color: submitMessage.includes('❌') ? '#721c24' : '#155724',
                   fontSize: 14,
                   textAlign: 'center'
                 }}>

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -27,7 +27,6 @@ export const SubmitPayload = z.object({
   items: z.array(ScoreItem)
     .min(1, "Необходимо оценить хотя бы один навык")
     .max(100, "Слишком много элементов"),
-  mode: z.enum(["draft", "final"]).default("final"),
 });
 
 // Схема для админ-запросов


### PR DESCRIPTION
## Summary
- remove "Сохранить черновик" admin button and draft save handler
- drop `mode` field and draft logic from form API and validation schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4880f712083208ff7b8c0bcaa4374