### PR TITLE
Simplify skill info lookup

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -38,6 +38,7 @@ export const PROP = {
   employee: "Сотрудник",
   cycle: "Цикл",
   skill: "Навык",
+  skillName: "Навык - название",
   role: "Роль",
   skillDescription: "Описание навыка",
   
@@ -803,121 +804,63 @@ export async function listEvaluateesForReviewerUser(userId) {
 async function loadSkillInformation(skillId, matrixRowProps) {
   try {
     console.log(`[SKILL LOAD] Loading skill: ${skillId}`);
-    
-    // Кэширование информации о навыках
+
     const cacheKey = `skill_info_${skillId}`;
     const cached = getCached(cacheKey);
     if (cached) {
       console.log(`[SKILL LOAD] ✅ Using cached data for skill: ${cached.name}`);
       return cached;
     }
-    
+
     let skillName = "Неизвестный навык";
     let skillDescription = "";
-    
-    // Проверяем rollup поле "Описание навыка" в текущей строке матрицы
-    if (matrixRowProps && matrixRowProps[PROP.skillDescription]) {
-      const rollupField = matrixRowProps[PROP.skillDescription];
-      console.log(`[SKILL LOAD] Found rollup field, type: ${rollupField?.type}`);
 
-      // Rollup поле может содержать массив значений
-      if (rollupField?.type === "rollup" && rollupField.rollup?.array) {
-        const rollupValues = rollupField.rollup.array;
-        console.log(`[SKILL LOAD] Rollup array has ${rollupValues.length} values`);
-
-        if (rollupValues.length > 0) {
-          // Берем первое непустое значение из rollup
-          for (const value of rollupValues) {
-            if (value?.rich_text?.length > 0) {
-              skillDescription = value.rich_text.map(t => t.plain_text).join("");
-              console.log(`[SKILL LOAD] Found description in rollup rich_text`);
-            }
-            if (value?.title?.length > 0) {
-              skillName = value.title.map(t => t.plain_text).join("");
-              console.log(`[SKILL LOAD] Found name in rollup title`);
-            }
-            if (skillDescription && skillName !== "Неизвестный навык") break;
+    // Rollup "Навык - название" содержит название навыка
+    const nameRollupField = matrixRowProps?.[PROP.skillName];
+    if (nameRollupField?.type === "rollup") {
+      const rollup = nameRollupField.rollup || {};
+      if (rollup.array?.length) {
+        for (const item of rollup.array) {
+          if (item.type === "title" && item.title?.length) {
+            skillName = item.title.map(t => t.plain_text).join("");
+          } else if (item.type === "rich_text" && item.rich_text?.length) {
+            skillName = item.rich_text.map(t => t.plain_text).join("");
           }
         }
-      } else if (rollupField?.rollup?.rich_text?.length > 0) {
-        // Простое rollup значение
-        skillDescription = rollupField.rollup.rich_text.map(t => t.plain_text).join("");
-        console.log(`[SKILL LOAD] Found description in simple rollup rich_text`);
-      } else if (rollupField?.rollup?.title?.length > 0) {
-        skillName = rollupField.rollup.title.map(t => t.plain_text).join("");
-        console.log(`[SKILL LOAD] Found name in simple rollup title`);
-      }
-
-      if (skillDescription && skillName === "Неизвестный навык") {
-        // Пытаемся извлечь название из начала описания
-        const lines = skillDescription.split('\n');
-        if (lines.length > 0 && lines[0].trim().length > 0 && lines[0].length < 100) {
-          skillName = lines[0].trim();
+      } else {
+        if (rollup.title?.length) {
+          skillName = rollup.title.map(t => t.plain_text).join("");
+        } else if (rollup.rich_text?.length) {
+          skillName = rollup.rich_text.map(t => t.plain_text).join("");
         }
       }
     }
 
-    // Загружаем страницу навыка напрямую, если имя все еще неизвестно или нет описания
-    try {
-      if (skillName === "Неизвестный навык" || !skillDescription) {
-        console.log(`[SKILL LOAD] Fetching skill page for: ${skillId}`);
-
-        const skillPage = await notionApiCall(() =>
-          notion.pages.retrieve({ page_id: skillId })
-        );
-
-        const props = skillPage.properties || {};
-
-        // Ищем title поле
-        const pageTitle = getTitleFromProps(props);
-        if (pageTitle && pageTitle.trim() && pageTitle !== "Untitled") {
-          skillName = pageTitle.trim();
-          console.log(`[SKILL LOAD] Found skill name: ${skillName}`);
-        }
-
-        // Ищем описание в свойствах страницы навыка, только если еще нет описания
-        if (!skillDescription) {
-          for (const [key, value] of Object.entries(props)) {
-            if (value?.type === "rich_text" && value.rich_text?.length > 0) {
-              const keyLower = key.toLowerCase();
-              if (keyLower.includes("описан") ||
-                  keyLower.includes("description") ||
-                  keyLower.includes("дескрипш") ||
-                  keyLower.includes("content") ||
-                  keyLower.includes("детал") ||
-                  keyLower.includes("text")) {
-                skillDescription = value.rich_text.map(t => t.plain_text).join("");
-                console.log(`[SKILL LOAD] Found description in field: ${key}`);
-                break;
-              }
-            }
+    // Rollup "Описание навыка" содержит описание навыка
+    const descriptionRollupField = matrixRowProps?.[PROP.skillDescription];
+    if (descriptionRollupField?.type === "rollup") {
+      const rollup = descriptionRollupField.rollup || {};
+      if (rollup.array?.length) {
+        for (const item of rollup.array) {
+          if (item.type === "rich_text" && item.rich_text?.length) {
+            skillDescription = item.rich_text.map(t => t.plain_text).join("");
           }
         }
-      }
-
-      const result = { name: skillName, description: skillDescription };
-      setCached(cacheKey, result);
-      console.log(`[SKILL LOAD] ✅ Loaded skill: ${skillName}`);
-      return result;
-
-    } catch (pageError) {
-      console.warn(`[SKILL LOAD] Failed to load skill page ${skillId}:`, pageError.message);
-
-      // Используем ID как fallback название
-      if (skillName === "Неизвестный навык") {
-        skillName = `Навык ${skillId.substring(-8)}`;
+      } else if (rollup.rich_text?.length) {
+        skillDescription = rollup.rich_text.map(t => t.plain_text).join("");
       }
     }
 
     const result = { name: skillName, description: skillDescription };
     setCached(cacheKey, result);
+    console.log(`[SKILL LOAD] ✅ Loaded skill: ${skillName}`);
     return result;
-    
+
   } catch (error) {
     console.error(`[SKILL LOAD] Critical error loading skill ${skillId}:`, error.message);
-    const result = { 
-      name: `Навык ${skillId.substring(-8)}`, 
-      description: `Ошибка загрузки: ${error.message}` 
+    const result = {
+      name: `Навык ${skillId.substring(-8)}`,
+      description: `Ошибка загрузки: ${error.message}`
     };
     return result;
   }


### PR DESCRIPTION
## Summary
- read skill name from "Навык - название" rollup instead of relation
- keep description retrieval from rollup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a48d0cc80883208af0bf7e3a382f5b