### PR TITLE
Use rollup field for skill name

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -38,6 +38,7 @@ export const PROP = {
   employee: "Сотрудник",
   cycle: "Цикл",
   skill: "Навык",
+  skillName: "Навык - название",
   role: "Роль",
   skillDescription: "Описание навыка",
   
@@ -814,36 +815,53 @@ async function loadSkillInformation(skillId, matrixRowProps) {
     let skillName = "Неизвестный навык";
     let skillDescription = "";
 
-    // Relation "Навык" может содержать название связанной страницы
-    const relationField = matrixRowProps?.[PROP.skill];
-    if (relationField?.type === "relation") {
-      const related = relationField.relation?.[0];
-      if (related?.name) {
-        skillName = related.name.trim();
-      }
-    }
-
-    // Rollup "Описание навыка" содержит название и описание навыка
-    const rollupField = matrixRowProps?.[PROP.skillDescription];
-    if (rollupField?.type === "rollup") {
-      const rollup = rollupField.rollup || {};
+    // Rollup "Навык - название" содержит название навыка
+    const nameRollupField = matrixRowProps?.[PROP.skillName];
+    if (nameRollupField?.type === "rollup") {
+      const rollup = nameRollupField.rollup || {};
       if (rollup.array?.length) {
         for (const item of rollup.array) {
           if (item.type === "title" && item.title?.length) {
             skillName = item.title.map(t => t.plain_text).join("");
+            break;
           }
           if (item.type === "rich_text" && item.rich_text?.length) {
-            skillDescription = item.rich_text.map(t => t.plain_text).join("");
+            skillName = item.rich_text.map(t => t.plain_text).join("");
+            break;
           }
         }
       } else {
         if (rollup.title?.length) {
           skillName = rollup.title.map(t => t.plain_text).join("");
         }
+        if (!skillName && rollup.rich_text?.length) {
+          skillName = rollup.rich_text.map(t => t.plain_text).join("");
+        }
+      }
+    } else if (nameRollupField?.title?.length) {
+      skillName = nameRollupField.title.map(t => t.plain_text).join("");
+    } else if (nameRollupField?.rich_text?.length) {
+      skillName = nameRollupField.rich_text.map(t => t.plain_text).join("");
+    }
+
+    // Rollup "Описание навыка" содержит описание навыка
+    const descRollupField = matrixRowProps?.[PROP.skillDescription];
+    if (descRollupField?.type === "rollup") {
+      const rollup = descRollupField.rollup || {};
+      if (rollup.array?.length) {
+        for (const item of rollup.array) {
+          if (item.type === "rich_text" && item.rich_text?.length) {
+            skillDescription = item.rich_text.map(t => t.plain_text).join("");
+            break;
+          }
+        }
+      } else {
         if (rollup.rich_text?.length) {
           skillDescription = rollup.rich_text.map(t => t.plain_text).join("");
         }
       }
+    } else if (descRollupField?.rich_text?.length) {
+      skillDescription = descRollupField.rich_text.map(t => t.plain_text).join("");
     }
 
     const result = { name: skillName, description: skillDescription };


### PR DESCRIPTION
## Summary
- derive skill name from the `Навык - название` rollup property
- add `skillName` constant to Notion property map

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a499c259bc83208d394c5626c209c6