### PR TITLE
Add queue-based score processing

### DIFF
--- a/app/api/form/[token]/route.js
+++ b/app/api/form/[token]/route.js
@@ -427,7 +427,7 @@ export async function POST(req, { params }) {
     }
     
     const { verifyReviewToken } = tokenModule;
-    const { updateScore, ROLE_TO_FIELD, PerformanceTracker } = notionModule;
+    const { ROLE_TO_FIELD } = notionModule;
     
     // Проверка токена
     let payload;
@@ -495,47 +495,38 @@ export async function POST(req, { params }) {
     const items = body.items;
 
     console.log(`[FORM POST] Роль из токена: ${role}`);
-    
-    // Batch обновление с параллельной отправкой
-    PerformanceTracker?.start('batch-update');
-    const results = [];
-    const BATCH_SIZE = 3;
 
-    for (let i = 0; i < items.length; i += BATCH_SIZE) {
-      const batch = items.slice(i, i + BATCH_SIZE);
-
-      const batchPromises = batch.map((item, idx) => {
-        const itemRole = item.role && ROLE_TO_FIELD[item.role] ? item.role : role;
-        const field = ROLE_TO_FIELD[itemRole] || ROLE_TO_FIELD.peer;
-
-        console.log(
-          `[FORM POST] Добавление ${i + idx + 1}/${items.length}: ${item.pageId} = ${item.value} -> ${field}`
-        );
-
-        return updateScore(item.pageId, field, item.value).then(() => ({
-          pageId: item.pageId,
-          field,
-          value: item.value,
-        }));
-      });
-
-      const batchResults = await Promise.all(batchPromises);
-      results.push(...batchResults);
+    const queue = process.env.SCORE_QUEUE;
+    if (!queue) {
+      console.error('[FORM POST] Queue binding SCORE_QUEUE is missing');
+      return NextResponse.json(
+        { error: 'Queue binding not configured' },
+        { status: 500 }
+      );
     }
 
-    const duration = PerformanceTracker?.end('batch-update') || 0;
+    const messages = items.map(item => ({
+      pageId: item.pageId,
+      value: item.value,
+      role: item.role && ROLE_TO_FIELD[item.role] ? item.role : role
+    }));
 
-    console.log(`[FORM POST] Обновлено ${results.length} элементов за ${duration}ms`);
-
-    const response = {
-      ok: true,
-      queued: results.length,
-      reviewerRole: role,
-      duration,
-      message: `Обновлено ${results.length} оценок`
-    };
-
-    return NextResponse.json(response);
+    try {
+      await queue.sendBatch(messages.map(body => ({ body })));
+      console.log(`[FORM POST] В очередь добавлено ${messages.length} элементов`);
+      return NextResponse.json({
+        ok: true,
+        queued: messages.length,
+        reviewerRole: role,
+        message: `В очередь добавлено ${messages.length} элементов`
+      });
+    } catch (err) {
+      console.error('[FORM POST] Ошибка отправки в очередь:', err);
+      return NextResponse.json(
+        { error: 'Ошибка добавления в очередь' },
+        { status: 500 }
+      );
+    }
     
   } catch (error) {
     console.error('[FORM POST КРИТИЧЕСКАЯ ОШИБКА]', {

--- a/score-worker.js
+++ b/score-worker.js
@@ -1,0 +1,20 @@
+import { updateScore, ROLE_TO_FIELD } from "./lib/notion";
+import rateLimit from "./lib/rateLimit";
+
+export default {
+  async queue(batch) {
+    for (const message of batch.messages) {
+      const { pageId, value, role } = message.body || {};
+      const field = ROLE_TO_FIELD[role] || ROLE_TO_FIELD.peer;
+      try {
+        await rateLimit.wait();
+        await updateScore(pageId, field, value);
+        console.log(`[QUEUE] Updated ${pageId} -> ${field} = ${value}`);
+      } catch (error) {
+        console.error(`[QUEUE] Failed to update ${pageId}:`, error);
+        rateLimit.recordError?.(error);
+        message.retry();
+      }
+    }
+  }
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,5 +6,19 @@
   
   "limits": {
     "cpu_ms": 60000
+  },
+  "queues": {
+    "producers": [
+      {
+        "queue": "score-updates",
+        "binding": "SCORE_QUEUE"
+      }
+    ],
+    "consumers": [
+      {
+        "queue": "score-updates",
+        "script_name": "score-worker"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- enqueue form submissions to SCORE_QUEUE instead of updating Notion directly
- add Cloudflare Queue worker to process score updates with rate limiting and retries
- configure wrangler to bind and consume the score-updates queue

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b8bef73c83209cfa5d16dbdfc514