### PR TITLE
feat: use Cloudflare KV for batch notion updates

### DIFF
--- a/app/api/form/[token]/route.js
+++ b/app/api/form/[token]/route.js
@@ -27,6 +27,19 @@ async function importNotionModule() {
   }
 }
 
+// Импорт модуля работы с очередями Cloudflare KV
+async function importKVModule() {
+  try {
+    console.log('[IMPORT] Импорт модуля KV очередей...');
+    const module = await import("@/lib/kv-queue");
+    console.log('[IMPORT] KV модуль импортирован');
+    return module;
+  } catch (error) {
+    console.error('[IMPORT] Ошибка импорта KV модуля:', error);
+    throw new Error(`Ошибка импорта модуля: '@/lib/kv-queue' - ${error.message}`);
+  }
+}
+
 // Проверка окружения
 function validateRuntimeEnvironment() {
   const checks = {
@@ -496,46 +509,73 @@ export async function POST(req, { params }) {
 
     console.log(`[FORM POST] Роль из токена: ${role}`);
     
-    // Batch обновление с параллельной отправкой
+    // Подготовка операций в формате batch API Notion
+    const operations = items.map(item => {
+      const itemRole = item.role && ROLE_TO_FIELD[item.role] ? item.role : role;
+      const field = ROLE_TO_FIELD[itemRole] || ROLE_TO_FIELD.peer;
+
+      return {
+        pageId: item.pageId,
+        properties: {
+          [field]: { number: item.value }
+        }
+      };
+    });
+
+    // Импортируем модуль очередей KV
+    let kvModule;
+    try {
+      kvModule = await importKVModule();
+    } catch (kvError) {
+      console.warn('[FORM POST] KV модуль недоступен:', kvError.message);
+    }
+
+    const { NotionBatchProcessor, isKVConnected } = kvModule || {};
+
+    // Запускаем обработку через процессор batch операций
     PerformanceTracker?.start('batch-update');
-    const results = [];
-    const BATCH_SIZE = 3;
 
-    for (let i = 0; i < items.length; i += BATCH_SIZE) {
-      const batch = items.slice(i, i + BATCH_SIZE);
-
-      const batchPromises = batch.map((item, idx) => {
-        const itemRole = item.role && ROLE_TO_FIELD[item.role] ? item.role : role;
-        const field = ROLE_TO_FIELD[itemRole] || ROLE_TO_FIELD.peer;
-
-        console.log(
-          `[FORM POST] Добавление ${i + idx + 1}/${items.length}: ${item.pageId} = ${item.value} -> ${field}`
-        );
-
-        return updateScore(item.pageId, field, item.value).then(() => ({
-          pageId: item.pageId,
-          field,
-          value: item.value,
-        }));
+    let result;
+    if (NotionBatchProcessor) {
+      const processor = new NotionBatchProcessor(notionModule.notion, {
+        reviewerUserId,
+        useKV: isKVConnected?.() && operations.length > 20
       });
-
-      const batchResults = await Promise.all(batchPromises);
-      results.push(...batchResults);
+      result = await processor.processBatch(operations);
+    } else {
+      // Fallback на прямое обновление, если процессор недоступен
+      result = {
+        mode: 'direct',
+        results: await Promise.all(operations.map(op =>
+          updateScore(op.pageId, Object.keys(op.properties)[0], op.properties[Object.keys(op.properties)[0]].number).then(() => ({
+            operation: op,
+            status: 'success'
+          }))
+        )),
+        stats: { total: operations.length, successful: operations.length, failed: 0 }
+      };
     }
 
     const duration = PerformanceTracker?.end('batch-update') || 0;
 
-    console.log(`[FORM POST] Обновлено ${results.length} элементов за ${duration}ms`);
+    console.log(`[FORM POST] Режим обработки: ${result.mode}, элементов: ${operations.length}, время: ${duration}ms`);
 
-    const response = {
+    return NextResponse.json({
       ok: true,
-      queued: results.length,
       reviewerRole: role,
       duration,
-      message: `Обновлено ${results.length} оценок`
-    };
-
-    return NextResponse.json(response);
+      mode: result.mode,
+      ...(result.mode === 'kv_queue'
+        ? {
+            queued: operations.length,
+            jobIds: result.jobIds,
+            message: `Операции добавлены в очередь KV. Создано ${result.totalJobs} задач`
+          }
+        : {
+            updated: result.stats.successful,
+            message: `Обновлено ${result.stats.successful} из ${result.stats.total} оценок`
+          })
+    });
     
   } catch (error) {
     console.error('[FORM POST КРИТИЧЕСКАЯ ОШИБКА]', {


### PR DESCRIPTION
## Summary
- integrate Cloudflare KV queue into form submission API
- add dynamic import for KV queue module and process batch operations via NotionBatchProcessor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4cd2089948320b7c5fa68934e2544