### PR TITLE
Включение Cloudflare KV для крупных batch операций

### DIFF
--- a/app/api/batch/submit/route.js
+++ b/app/api/batch/submit/route.js
@@ -9,7 +9,7 @@ import { notion } from "@/lib/notion";
 // Лимиты безопасности для разных режимов обработки
 const LIMITS = {
   DIRECT_PROCESSING: {
-    maxOperations: 100,      // Максимум операций для прямой обработки
+    maxOperations: 50,      // Максимум операций для прямой обработки
     maxOperationSize: 8000   // Максимальный размер одной операции (символы)
   },
   KV_QUEUE: {
@@ -97,8 +97,11 @@ export async function POST(req) {
     let processingMode = 'direct';
     let limits = LIMITS.DIRECT_PROCESSING;
 
+    // Принудительное использование KV, если запрошено
+    const forceKV = options.forceKV === true || body.forceKV === true;
+
     // Выбираем режим обработки на основе размера и доступности KV
-    if (kvAvailable && operations.length > LIMITS.DIRECT_PROCESSING.maxOperations) {
+    if (kvAvailable && (operations.length > LIMITS.DIRECT_PROCESSING.maxOperations || forceKV)) {
       processingMode = 'kv_queue';
       limits = LIMITS.KV_QUEUE;
     }

--- a/app/form/[token]/page.jsx
+++ b/app/form/[token]/page.jsx
@@ -729,6 +729,11 @@ export default function SkillsAssessmentForm({ params }) {
           maxRetries: 3
         };
       }
+
+        // Для больших пакетов принудительно используем Cloudflare KV
+        if (operations.length > 50) {
+          batchOptions.forceKV = true;
+        }
       
       // Отправляем через новый batch API
       const response = await fetch('/api/batch/submit', {


### PR DESCRIPTION
## Summary
- Обработчик batch-запросов теперь использует Cloudflare KV при отправке более 50 операций или при принудительном запросе
- Форма оценки отправляет большие пакеты в KV, что предотвращает ошибки при массовой отправке оценок

## Testing
- `npm test` *(скрипт отсутствует)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4d382bd7c8320ac3ad025e57d8fc4