### PR TITLE
Initialize Cloudflare KV from request context

### DIFF
--- a/app/api/batch/results/route.js
+++ b/app/api/batch/results/route.js
@@ -2,13 +2,14 @@
 export const runtime = "edge";
 
 import { NextResponse } from "next/server";
-import { getKVBatchResults, getKVBatchStatus, isKVConnected } from "@/lib/kv-queue";
+import { getKVBatchResults, getKVBatchStatus, isKVConnected, initKV } from "@/lib/kv-queue";
 
 // Кэш для результатов (они меняются реже чем статус)
 const resultsCache = new Map();
 const CACHE_TTL = 10000; // Кэшируем результаты на 10 секунд
 
-export async function GET(req) {
+export async function GET(req, context) {
+  initKV(context.env);
   console.log('[BATCH RESULTS] Получен запрос на результаты batch операций');
   
   try {

--- a/app/api/batch/status/route.js
+++ b/app/api/batch/status/route.js
@@ -2,13 +2,14 @@
 export const runtime = "edge";
 
 import { NextResponse } from "next/server";
-import { getKVBatchStatus, isKVConnected } from "@/lib/kv-queue";
+import { getKVBatchStatus, isKVConnected, initKV } from "@/lib/kv-queue";
 
 // Кэш для часто запрашиваемых статусов (в памяти Edge Runtime)
 const statusCache = new Map();
 const CACHE_TTL = 3000; // Кэшируем статусы на 3 секунды (быстрее чем Redis версия)
 
-export async function GET(req) {
+export async function GET(req, context) {
+  initKV(context.env);
   console.log('[BATCH STATUS] Получен GET запрос на проверку статуса');
   
   try {

--- a/app/api/batch/submit/route.js
+++ b/app/api/batch/submit/route.js
@@ -3,7 +3,7 @@ export const runtime = "edge";
 
 import { NextResponse } from "next/server";
 import { verifyReviewToken } from "@/lib/token";
-import { NotionBatchProcessor, addBatchToKVQueue, isKVConnected } from "@/lib/kv-queue";
+import { NotionBatchProcessor, addBatchToKVQueue, isKVConnected, initKV } from "@/lib/kv-queue";
 import { notion } from "@/lib/notion";
 
 // Лимиты безопасности для разных режимов обработки
@@ -23,7 +23,8 @@ const LIMITS = {
   }
 };
 
-export async function POST(req) {
+export async function POST(req, context) {
+  initKV(context.env);
   console.log('[BATCH SUBMIT] ===== Новый запрос на batch обработку =====');
   
   try {
@@ -400,7 +401,8 @@ async function handleDirectProcessing(operations, options) {
 }
 
 // GET endpoint для получения информации о возможностях системы
-export async function GET() {
+export async function GET(req, context) {
+  initKV(context.env);
   return NextResponse.json({
     service: "Notion Batch Operations API",
     version: "2.0.0",

--- a/lib/kv-queue.js
+++ b/lib/kv-queue.js
@@ -5,19 +5,16 @@
 let KV_NAMESPACE = null;
 let isKVAvailable = false;
 
-try {
-  // В Edge Runtime Cloudflare KV доступно через глобальную переменную
-  // Имя переменной должно совпадать с названием в wrangler.toml
-  if (typeof NOTION_QUEUE_KV !== 'undefined') {
-    KV_NAMESPACE = NOTION_QUEUE_KV;
-    isKVAvailable = true;
+// Инициализация KV с передачей объекта окружения
+export function initKV(env = {}) {
+  KV_NAMESPACE = env?.NOTION_QUEUE_KV || null;
+  isKVAvailable = Boolean(KV_NAMESPACE);
+
+  if (isKVAvailable) {
     console.log('[KV] Cloudflare KV подключено успешно');
   } else {
     console.warn('[KV] Cloudflare KV недоступно (вероятно, локальная разработка)');
   }
-} catch (error) {
-  console.error('[KV] Ошибка инициализации KV:', error.message);
-  isKVAvailable = false;
 }
 
 // Ключи для организации данных в KV


### PR DESCRIPTION
## Summary
- introduce `initKV(env)` to configure KV namespace dynamically
- initialize KV in batch API routes using request context

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4e92c0f7c8320b4b0c09d18de9681