### PR TITLE
Improve KV detection and fail fast when unavailable

### DIFF
--- a/lib/kv-queue.js
+++ b/lib/kv-queue.js
@@ -6,9 +6,16 @@ let KV_NAMESPACE = null;
 let isKVAvailable = false;
 
 // Инициализация KV с передачей объекта окружения
+// В среде Cloudflare объект KV приходит через context.env. При локальной
+// разработке или запуске без Pages functions переменная может быть
+// доступна глобально, поэтому добавляем дополнительные проверки.
 export function initKV(env = {}) {
-  KV_NAMESPACE = env?.NOTION_QUEUE_KV || null;
-  isKVAvailable = Boolean(KV_NAMESPACE);
+  KV_NAMESPACE =
+    env?.NOTION_QUEUE_KV ||
+    globalThis?.NOTION_QUEUE_KV ||
+    null;
+
+  isKVAvailable = Boolean(KV_NAMESPACE && typeof KV_NAMESPACE.get === 'function');
 
   if (isKVAvailable) {
     console.log('[KV] Cloudflare KV подключено успешно');


### PR DESCRIPTION
## Summary
- detect Cloudflare KV namespace from global scope for local dev
- queue large batches only when KV is available and fail fast otherwise

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a4fa5d6dcc8320a32f8af79608e9eb